### PR TITLE
Fix pydevconsole unrecognized arguments error

### DIFF
--- a/run_experiments.py
+++ b/run_experiments.py
@@ -18,7 +18,8 @@ def main() -> None:
 		default=int(os.environ.get("OMP_NUM_THREADS", "1")),
 		help="Max threads for OMP/MKL backends (defaults to 1 if not set).",
 	)
-	args = parser.parse_args()
+	# Accept and ignore any unknown arguments that may be injected by IDE consoles
+	args, _unknown_args = parser.parse_known_args()
 
 	# Configure environment BEFORE importing libraries that may load OpenMP runtimes
 	os.environ.setdefault("OMP_NUM_THREADS", str(args.threads))


### PR DESCRIPTION
Switch to `parse_known_args` to ignore IDE-injected CLI arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-da08878b-39fa-45d7-8cab-9cb09c3037a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da08878b-39fa-45d7-8cab-9cb09c3037a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

